### PR TITLE
Fix compilation on Xcode 4.6

### DIFF
--- a/imp_1199.xml
+++ b/imp_1199.xml
@@ -54,7 +54,11 @@
 
       unsigned int fft_length[IMPULSES];
 
+#ifdef __clang__
+      void impulse2freq(int id, float *imp, unsigned int length, fftw_real *out)
+#else
       inline void impulse2freq(int id, float *imp, unsigned int length, fftw_real *out)
+#endif
       {
         fftw_real impulse_time[MAX_FFT_LENGTH];
 #ifdef FFTW3


### PR DESCRIPTION
Removes the inline declaration for the clang compiler, which fixes the following compilation error in lmms:
```
Linking C shared module imp_1199.so
Undefined symbols for architecture x86_64:
   "_impulse2freq", referenced from:
      _mk_imps in imp_1199.o
ld: symbol(s) not found for architecture x86_64
clang: error linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [plugins/LadspaEffect/swh/imp_1199.so] Error 1
make[1]: *** [plugins/LadspaEffect/swh/CMakeFiles/imp_1199.dir/all] Error 2
```

Note, this didn't seem to be a problem with Clang 5.x, but we're trying to add compat for older OSs, hence the old Xcode version. :)