### PR TITLE
gcc5 does not support recursive inline functions

### DIFF
--- a/sifter_1210.xml
+++ b/sifter_1210.xml
@@ -13,11 +13,7 @@
 
 inline int partition(LADSPA_Data array[], int left, int right);
 
-#ifdef __clang__
 void q_sort(LADSPA_Data array[], int left, int right) {
-#else
-inline void q_sort(LADSPA_Data array[], int left, int right) {
-#endif
 	float pivot = partition(array, left, right);
 
 	if (left < pivot) {


### PR DESCRIPTION
gcc5 produces a warning only.
Loading the plugin fails with "undefined symbol: q_sort"

Explicit `inline` is probably overrated in this case. I assume gcc4 ignored the `inline` and not recursively unrolled the inline function, so I didn't add an  `#if __GNUC__ > 4` case on top of the `__clang__` check.