### PR TITLE
Fix uninitialized, unused-but-set-variable and unused-variable warnings

### DIFF
--- a/allpass_1895.xml
+++ b/allpass_1895.xml
@@ -42,6 +42,14 @@
     
     <callback event="instantiate"><![CDATA[
       sample_rate = s_rate;
+
+      // Uninitialized variables
+      buffer_mask = 0;
+      delay_samples = 0;
+      feedback = 0;
+      last_decay_time = 0;
+      last_delay_time = 0;
+      write_phase = 0;
     ]]></callback>
     
     <callback event="activate"><![CDATA[
@@ -225,6 +233,14 @@
     
     <callback event="instantiate"><![CDATA[
       sample_rate = s_rate;
+
+      // Uninitialized variables
+      buffer_mask = 0;
+      delay_samples = 0;
+      feedback = 0;
+      last_decay_time = 0;
+      last_delay_time = 0;
+      write_phase = 0;
     ]]></callback>
     
     <callback event="activate"><![CDATA[
@@ -255,6 +271,8 @@
     
     <callback event="run"><![CDATA[
       int i;
+
+      ignore(max_delay);
 
       if (write_phase == 0) {
         plugin_data->last_delay_time = delay_time;
@@ -363,6 +381,14 @@
     
     <callback event="instantiate"><![CDATA[
       sample_rate = s_rate;
+
+      // Uninitialized variables
+      buffer_mask = 0;
+      delay_samples = 0;
+      feedback = 0;
+      last_decay_time = 0;
+      last_delay_time = 0;
+      write_phase = 0;
     ]]></callback>
     
     <callback event="activate"><![CDATA[
@@ -393,6 +419,8 @@
     
     <callback event="run"><![CDATA[
       int i;
+
+      ignore(max_delay);
 
       if (write_phase == 0) {
         plugin_data->last_delay_time = delay_time;

--- a/bandpass_a_iir_1893.xml
+++ b/bandpass_a_iir_1893.xml
@@ -24,6 +24,9 @@
 		<callback event="run">
                   calc_2polebandpass(iirf, gt, center, width, sample_rate);
                   iir_process_buffer_1s_5(iirf, gt, input, output, sample_count,0);
+
+                  // Unused variable
+                  (void)(run_adding_gain);
                 </callback>
 
                 <callback event="activate">                  

--- a/bandpass_iir_1892.xml
+++ b/bandpass_iir_1892.xml
@@ -22,6 +22,10 @@
 
                 <callback event="instantiate">
                   sample_rate = s_rate;
+
+                  // Uninitialized variables
+                  lfc = 0;
+                  ufc = 0;
                 </callback>
 		<callback event="run">
                   ufc = (center + width*0.5f)/(float)sample_rate;
@@ -30,6 +34,9 @@
                                      chebyshev(iirf, first,  2*CLAMP((int)stages,1,10), IIR_STAGE_LOWPASS,  ufc, 0.5f),
                                      chebyshev(iirf, second, 2*CLAMP((int)stages,1,10), IIR_STAGE_HIGHPASS, lfc, 0.5f));
                   iir_process_buffer_ns_5(iirf, gt, input, output, sample_count,RUN_ADDING);
+
+                  // Unused variable
+                  (void)(run_adding_gain);
                 </callback>
 
                 <callback event="activate">                  

--- a/butterworth_1902.xml
+++ b/butterworth_1902.xml
@@ -25,6 +25,9 @@
                   butterworth_stage(gt, 0, cutoff, resonance, sample_rate);
                   iir_process_buffer_1s_5(iirf, gt, input, lpoutput, sample_count,0);
 		  buffer_sub(input, lpoutput, hpoutput, sample_count);
+
+                  // Unused variable
+                  (void)(run_adding_gain);
                 </callback>
 
                 <callback event="activate">                  
@@ -79,6 +82,9 @@
 		<callback event="run">
                   butterworth_stage(gt, 0, cutoff, resonance, sample_rate);
                   iir_process_buffer_1s_5(iirf, gt, input, output, sample_count,0);
+
+                  // Unused variable
+                  (void)(run_adding_gain);
                 </callback>
 
                 <callback event="activate">                  
@@ -129,6 +135,9 @@
 		<callback event="run">
                   butterworth_stage(gt, 1, cutoff, resonance, sample_rate);
                   iir_process_buffer_1s_5(iirf, gt, input, output, sample_count,0);
+
+                  // Unused variable
+                  (void)(run_adding_gain);
                 </callback>
 
                 <callback event="activate">                  

--- a/comb_1887.xml
+++ b/comb_1887.xml
@@ -39,6 +39,14 @@
     
     <callback event="instantiate"><![CDATA[
       sample_rate = s_rate;
+
+      // Uninitialized variables
+      buffer_mask = 0;
+      delay_samples = 0;
+      feedback = 0;
+      last_decay_time = 0;
+      last_delay_time = 0;
+      write_phase = 0;
     ]]></callback>
     
     <callback event="activate"><![CDATA[
@@ -219,6 +227,14 @@
     
     <callback event="instantiate"><![CDATA[
       sample_rate = s_rate;
+
+      // Uninitialized variables
+      buffer_mask = 0;
+      delay_samples = 0;
+      feedback = 0;
+      last_decay_time = 0;
+      last_delay_time = 0;
+      write_phase = 0;
     ]]></callback>
     
     <callback event="activate"><![CDATA[
@@ -357,6 +373,14 @@
     
     <callback event="instantiate"><![CDATA[
       sample_rate = s_rate;
+
+      // Uninitialized variables
+      buffer_mask = 0;
+      delay_samples = 0;
+      feedback = 0;
+      last_decay_time = 0;
+      last_delay_time = 0;
+      write_phase = 0;
     ]]></callback>
     
     <callback event="activate"><![CDATA[

--- a/decay_1886.xml
+++ b/decay_1886.xml
@@ -22,6 +22,12 @@
     
     <callback event="instantiate"><![CDATA[
       sample_rate = s_rate;
+
+      // Uninitialized variables
+      b = 0;
+      first_time = 0;
+      last_decay_time = 0;
+      y = 0;
     ]]></callback>
     
     <callback event="activate"><![CDATA[

--- a/delay_1898.xml
+++ b/delay_1898.xml
@@ -25,6 +25,12 @@
     
     <callback event="instantiate"><![CDATA[
       sample_rate = s_rate;
+
+      // Uninitialized variables
+      buffer_mask = 0;
+      delay_samples = 0;
+      last_delay_time = 0;
+      write_phase = 0;
     ]]></callback>
     
     <callback event="activate"><![CDATA[
@@ -112,6 +118,9 @@
       }
       
       plugin_data->write_phase = write_phase;
+
+      // Unused variable
+      (void)(max_delay);
     ]]></callback>
 
     <port label="in" dir="input" type="audio">
@@ -153,6 +162,12 @@
     
     <callback event="instantiate"><![CDATA[
       sample_rate = s_rate;
+
+      // Uninitialized variables
+      buffer_mask = 0;
+      delay_samples = 0;
+      last_delay_time = 0;
+      write_phase = 0;
     ]]></callback>
     
     <callback event="activate"><![CDATA[
@@ -228,6 +243,9 @@
       }
       
       plugin_data->write_phase = write_phase;
+
+      // Unused variable
+      (void)(max_delay);
     ]]></callback>
 
     <port label="in" dir="input" type="audio">
@@ -269,6 +287,12 @@
     
     <callback event="instantiate"><![CDATA[
       sample_rate = s_rate;
+
+      // Uninitialized variables
+      buffer_mask = 0;
+      delay_samples = 0;
+      last_delay_time = 0;
+      write_phase = 0;
     ]]></callback>
     
     <callback event="activate"><![CDATA[
@@ -325,7 +349,7 @@
 
         for (i=0; i<sample_count; i++) {
           long read_phase, idelay_samples;
-          LADSPA_Data written, frac, read;
+          LADSPA_Data frac, read;
 
           delay_samples += delay_samples_slope;
           write_phase++;
@@ -346,6 +370,9 @@
       }
       
       plugin_data->write_phase = write_phase;
+
+      // Unused variable
+      (void)(max_delay);
     ]]></callback>
 
     <port label="in" dir="input" type="audio">

--- a/highpass_iir_1890.xml
+++ b/highpass_iir_1890.xml
@@ -26,6 +26,9 @@
 		<callback event="run">
                   chebyshev(iirf, gt, 2*CLAMP((int)stages,1,10), IIR_STAGE_HIGHPASS, cutoff/(float)sample_rate, 0.5f);
                   iir_process_buffer_ns_5(iirf, gt, input, output, sample_count,RUN_ADDING);
+
+                  // Unused variable
+                  (void)(run_adding_gain);
                 </callback>
 
                 <callback event="activate">                  

--- a/lowpass_iir_1891.xml
+++ b/lowpass_iir_1891.xml
@@ -27,6 +27,9 @@
 		<callback event="run">
                   chebyshev(iirf, gt, 2*CLAMP((int)stages,1,10), IIR_STAGE_LOWPASS, cutoff/(float)sample_rate, 0.5f);
                   iir_process_buffer_ns_5(iirf, gt, input, output, sample_count,RUN_ADDING);
+
+                  // Unused variable
+                  (void)(run_adding_gain);
                 </callback>
 
                 <callback event="activate">                  

--- a/notch_iir_1894.xml
+++ b/notch_iir_1894.xml
@@ -30,6 +30,9 @@
                   chebyshev(iirf2, second, 2*CLAMP((int)stages,1,10), IIR_STAGE_HIGHPASS, lfc, 0.5f);
                   iir_process_buffer_ns_5(iirf1, first, input, output, sample_count, RUN_ADDING);
                   iir_process_buffer_ns_5(iirf2, second, input, output, sample_count, 1); /* add to first buffer */
+
+                  // Unused variable
+                  (void)(run_adding_gain);
                 </callback>
 
                 <callback event="activate">                  

--- a/revdelay_1605.xml
+++ b/revdelay_1605.xml
@@ -103,7 +103,7 @@
 
         for (i=0; i<sample_count; i++) {
           long read_phase, idelay_samples;
-          LADSPA_Data frac, read;
+          LADSPA_Data read;
           LADSPA_Data insamp;
           insamp = in[i];
 
@@ -113,7 +113,6 @@
 
           read_phase = delay2 - write_phase;
           idelay_samples = (long)delay_samples;
-          frac = delay_samples - idelay_samples;
           read = wet * buffer[read_phase]   + (dry * insamp);
 
           if ((write_phase % idelay_samples) < xfade_samp) {

--- a/util/pitchscale.c
+++ b/util/pitchscale.c
@@ -54,7 +54,7 @@ void pitch_scale(sbuffers *buffers, const double pitchScale, const long
 	Transform.  Author: (c)1999 Stephan M. Sprenger <sms@dspdimension.com>
 */
 	double magn, phase, tmp;
-	double freqPerBin, expct, fadeZoneLen;
+	double freqPerBin, expct;
         long i,k, qpd, index, inFifoLatency, stepSize,
 	  fftFrameSize2;
 	double phaseArr[MAX_FRAME_LENGTH];
@@ -88,7 +88,6 @@ void pitch_scale(sbuffers *buffers, const double pitchScale, const long
 	}
 
 	/* set up some handy variables */
-	fadeZoneLen = fftFrameLength/2;
 	fftFrameSize2 = fftFrameLength/2;
 	stepSize = fftFrameLength/osamp;
 	freqPerBin = sampleRate*2.0/(double)fftFrameLength;


### PR DESCRIPTION
This patch fixes some GCC warnings about initialization and unused variables.