### PR TITLE
avoid global namespace symbol conflicts and possible double free (again)

### DIFF
--- a/makestub.pl
+++ b/makestub.pl
@@ -87,7 +87,7 @@ print <<EOB;
 \#ifdef WIN32
 \#define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 \#else
 \#define _WINDOWS_DLL_EXPORT_ 
 \#endif
@@ -139,7 +139,7 @@ print "	default:\n		return NULL;\n	}\n}\n\n";
 print $code;
 # Headers for init section
 print <<EOB;
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -157,7 +157,7 @@ print "}\n";
 
 print <<EOB;
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 $fini_code
 }
 EOB


### PR DESCRIPTION
Re-instate 'static' on constructors & destructors, lost somewhere along the
way since a12ba80d.