### PR TITLE
Fix GCC 5.3.1 warnings

### DIFF
--- a/hermes_filter_1200.xml
+++ b/hermes_filter_1200.xml
@@ -97,7 +97,7 @@ inline void setup_f_svf(sv_filter *sv, const float fs, const float fc) {
 
 /* Run one sample through the SV filter. Filter is by andy@vellocet */
 
-inline float run_svf(sv_filter *sv, float in) {
+static inline float run_svf(sv_filter *sv, float in) {
 	float out;
 	int i;
 
@@ -124,7 +124,7 @@ inline float run_svf(sv_filter *sv, float in) {
 	return out;
 }
 
-inline int wave_tbl(const float wave) {
+static inline int wave_tbl(const float wave) {
 	switch (f_round(wave)) {
 		case 0:
 		return BLO_SINE;

--- a/imp_1199.xml
+++ b/imp_1199.xml
@@ -43,7 +43,7 @@
 
       #define MK_IMP(i) impulse2freq(c, i, IMP_LENGTH(i), impulse_freq[c]); c++
 
-      inline void impulse2freq(int id, float *imp, unsigned int length, fftw_real *out);
+      static inline void impulse2freq(int id, float *imp, unsigned int length, fftw_real *out);
 
       #include "impulses/all.h"
 
@@ -55,9 +55,9 @@
       unsigned int fft_length[IMPULSES];
 
 #ifdef __clang__
-      void impulse2freq(int id, float *imp, unsigned int length, fftw_real *out)
+      static void impulse2freq(int id, float *imp, unsigned int length, fftw_real *out)
 #else
-      inline void impulse2freq(int id, float *imp, unsigned int length, fftw_real *out)
+      static inline void impulse2freq(int id, float *imp, unsigned int length, fftw_real *out)
 #endif
       {
         fftw_real impulse_time[MAX_FFT_LENGTH];

--- a/impulses/all.h
+++ b/impulses/all.h
@@ -1,6 +1,6 @@
 /* Generated file, do not edit */
 
-#define IMPULSES      21
+#define IMPULSES 21
 
 #include "impulses/01-unit.h"
 #include "impulses/02-steves-flat.h"
@@ -25,9 +25,9 @@
 #include "impulses/21-matchless-chieftain-sm57-off.h"
 
 #ifdef __clang__
-void mk_imps(fftw_real **impulse_freq)
+static void mk_imps(fftw_real **impulse_freq)
 #else
-inline void mk_imps(fftw_real **impulse_freq)
+static inline void mk_imps(fftw_real **impulse_freq)
 #endif
 {
 	int c = 0;

--- a/impulses/mkall-h.sh
+++ b/impulses/mkall-h.sh
@@ -7,7 +7,11 @@ echo "#define IMPULSES $count" >> all.h
 echo "" >> all.h
 ls -1 [0-9][0-9]* | awk '{print "#include \"impulses/" $0 "\""}' >> all.h
 echo "" >> all.h
-echo "inline void mk_imps(fftw_real **impulse_freq)" >> all.h
+echo "#ifdef __clang__" >> all.h
+echo "static void mk_imps(fftw_real **impulse_freq)" >> all.h
+echo "#else" >> all.h
+echo "static inline void mk_imps(fftw_real **impulse_freq)" >> all.h
+echo "#endif" >> all.h
 echo "{" >> all.h
 echo "	int c = 0;" >> all.h
 ls -1 [0-9][0-9]* | sed 's/...//;s/\.h//;s/-/_/g' | awk '{print "\tMK_IMP(" $0 ");"}' >> all.h

--- a/retro_flange_1208.xml
+++ b/retro_flange_1208.xml
@@ -12,7 +12,7 @@
 
 #define BASE_BUFFER 0.001 // Base buffer length (s)
 
-inline LADSPA_Data sat(LADSPA_Data x, float q,  float dist) {
+static inline LADSPA_Data sat(LADSPA_Data x, float q,  float dist) {
 	if (x == q) {
 		return 1.0f / dist + q / (1.0f - f_exp(dist * q));
 	}

--- a/util/buffer.h
+++ b/util/buffer.h
@@ -6,12 +6,10 @@
  * this could be sped up by vector operations
  */
 
-static inline void buffer_sub(const float* a, const float *b, const float *c, int cnt) {
+static inline void buffer_sub(const float* a, const float *b, float *c, int cnt) {
 	int i;
-	float *h;
-	h = c;
 	for(i=0;i<cnt;++i)
-		*h++ = *a++ - *b++;
+		*c++ = *a++ - *b++;
 }
 
 #endif


### PR DESCRIPTION
This fixes the following warnings:

* `'`foo`' is static but used in inline function '`bar`' which is not static`<br>
I have not tested Clang.
* `assignment discards 'const' qualifier from pointer target type`