### PR TITLE
Fix Clang 3.8.1 warnings

### DIFF
--- a/analogue_osc_1416.xml
+++ b/analogue_osc_1416.xml
@@ -38,7 +38,7 @@
       blo_h_free(plugin_data->osc);
     ]]></callback>
 
-    <callback event="run"><![CDATA[
+    <callback event="run" unused-vars="tables"><![CDATA[
       unsigned long pos;
       LADSPA_Data x, y;
       const float q = warm - 0.999f;
@@ -48,8 +48,6 @@
       osc->wave = LIMIT(f_round(wave) - 1, 0, BLO_N_WAVES-1);
       osc->nyquist = fs * (0.47f - f_clamp(warm, 0.0f, 1.0f) * 0.41f);
       blo_hd_set_freq(osc, freq);
-
-      tables = tables; // So gcc doesn't think it's unused
 
       for (pos = 0; pos < sample_count; pos++) {
 	x = blo_hd_run_cub(osc);

--- a/configure.ac
+++ b/configure.ac
@@ -97,12 +97,24 @@ AC_ARG_ENABLE(darwin, [  --enable-darwin Builds plugins that will be shared obje
 
 CFLAGS="$lrintf_save_CFLAGS -I@top_srcdir@/intl -I@top_srcdir@"
 
+check_cc_flag() {
+  echo "int main(void){return 0;}" | $CC $CFLAGS $1 -o /dev/null -x c - 2> /dev/null
+}
+
 if [ echo ${CFLAGS} | grep "\-march=" ]; then
   AC_MSG_WARN([CFLAGS appears to allready contain architecture specifaction, using exiting one])
 else
   AC_MSG_WARN([Can't find architecture specifaction in CFLAGS])
 
-  CFLAGS="$CFLAGS -Wall -O3 -fomit-frame-pointer -fstrength-reduce -funroll-loops -ffast-math -fPIC -DPIC ${USE_SSE} ${DARWIN_CFLAGS}"
+  CFLAGS="$CFLAGS -Wall -O3 -fomit-frame-pointer -funroll-loops -ffast-math -fPIC -DPIC ${USE_SSE} ${DARWIN_CFLAGS}"
+
+  printf %s "checking if $CC supports -fstrength-reduce... "
+  if check_cc_flag -fstrength-reduce; then
+    echo yes
+    CFLAGS="$CFLAGS -fstrength-reduce"
+  else
+    echo no
+  fi
 
   dnl For Intel's C compiler use:
   dnl CC="icc"

--- a/fad_delay_1192.xml
+++ b/fad_delay_1192.xml
@@ -40,7 +40,6 @@
 			phase = 0;
 			last_phase = 0;
 			last_in = 0.0f;
-			sample_rate = sample_rate;
 		</callback>
 
 		<callback event="cleanup">

--- a/flanger_1191.xml
+++ b/flanger_1191.xml
@@ -86,7 +86,7 @@ for (pos = 0; pos < sample_count; pos++) {
 
 	// Calculate position in delay table
 	d_base = LIN_INTERP(frac, old_d_base, new_d_base);
-	n_ph = (float)(law_p - abs(next_law_pos - count))/(float)law_p;
+	n_ph = (float)(law_p - labs(next_law_pos - count))/(float)law_p;
 	p_ph = n_ph + 0.5f;
 	while (p_ph > 1.0f) {
 		p_ph -= 1.0f;

--- a/fm_osc_1415.xml
+++ b/fm_osc_1415.xml
@@ -21,11 +21,9 @@
       osc = blo_h_new(tables, BLO_SINE, (float)s_rate);
     ]]></callback>
 
-    <callback event="run"><![CDATA[
+    <callback event="run" unused-vars="tables"><![CDATA[
       unsigned long pos;
       osc->wave = LIMIT(f_round(wave) - 1, 0, BLO_N_WAVES-1);
-
-      tables = tables; // So gcc doesn't think it's unused
 
       for (pos = 0; pos < sample_count; pos++) {
 	blo_hd_set_freq(osc, fm[pos]);

--- a/gsm/gsm_create.c
+++ b/gsm/gsm_create.c
@@ -4,8 +4,6 @@
  * details.  THERE IS ABSOLUTELY NO WARRANTY FOR THIS SOFTWARE.
  */
 
-static char const	ident[] = "$Header: /home/cvs/giga/ladspa-swh/gsm/gsm_create.c,v 1.1 2001/06/10 21:36:51 swh Exp $";
-
 #include	"config.h"
 
 #ifdef	HAS_STRING_H

--- a/gsm/short_term.c
+++ b/gsm/short_term.c
@@ -53,7 +53,7 @@ static void Decoding_of_the_coded_Log_Area_Ratios P2((LARc,LARpp),
 #undef	STEP
 #define	STEP( B, MIC, INVA )	\
 		temp1    = GSM_ADD( *LARc++, MIC ) << 10;	\
-		temp1    = GSM_SUB( temp1, B << 1 );		\
+		temp1    = GSM_SUB( temp1, B * 2 );		\
 		temp1    = GSM_MULT_R( INVA, temp1 );		\
 		*LARpp++ = GSM_ADD( temp1, temp1 );
 

--- a/gsm_1215.xml
+++ b/gsm_1215.xml
@@ -57,15 +57,13 @@
       }
     ]]></callback>
 
-    <callback event="run"><![CDATA[
+    <callback event="run" unused-vars="fs"><![CDATA[
       unsigned long pos;
       gsm_frame frame;
       int samp;
       float part;
       int error_rate = f_round(error);
       int num_passes = f_round(passes);
-
-      fs = fs; // So gcc doesn't think it's unused
 
       for (pos = 0; pos < sample_count; pos++) {
 

--- a/hermes_filter_1200.xml
+++ b/hermes_filter_1200.xml
@@ -227,7 +227,7 @@ blo_h_free(plugin_data->lfo2_d);
 blo_h_tables_free(plugin_data->tables);
 		</callback>
 
-		<callback event="run"><![CDATA[
+		<callback event="run" unused-vars="tables"><![CDATA[
 unsigned long pos;
 int i;
 
@@ -332,8 +332,6 @@ dela_wet[2] = dela3_wet;
 dela_fb[0] = dela1_fb;
 dela_fb[1] = dela2_fb;
 dela_fb[2] = dela3_fb;
-
-tables = tables; // To shut up gcc
 
 for (pos = 0; pos < sample_count; pos++) {
 	count++; // Count of number of samples processed

--- a/ladspa-util.h
+++ b/ladspa-util.h
@@ -163,6 +163,8 @@ static inline float f_sin_sq(float angle)
 
 #define f_round(f) lrintf(f)
 
+#define f_abs(j) labs(j)
+
 #else
 
 // Round float to int using IEEE int* hack
@@ -175,6 +177,8 @@ static inline int f_round(float f)
 
 	return p.i - 0x4b400000;
 }
+
+#define f_abs(j) abs(j)
 
 #endif
 

--- a/multivoice_chorus_1201.xml
+++ b/multivoice_chorus_1201.xml
@@ -111,7 +111,7 @@ for (pos = 0; pos < sample_count; pos++) {
 	if (count % 16 < laws) {
 		unsigned int t = count % 16;
 		// Calculate sinus phases
-		float n_ph = (float)(law_p - abs(next_peak_pos[t] - count))/law_p;
+		float n_ph = (float)(law_p - labs(next_peak_pos[t] - count))/law_p;
 		float p_ph = n_ph + 0.5f;
 		if (p_ph > 1.0f) {
 			p_ph -= 1.0f;

--- a/pitch_scale_1193.xml
+++ b/pitch_scale_1193.xml
@@ -73,7 +73,6 @@
 			memset(buffers->gAnaFreq, 0, FRAME_LENGTH*sizeof(float));
 			memset(buffers->gAnaMagn, 0, FRAME_LENGTH*sizeof(float));
 			buffers->gRover = 0;
-			sample_rate = sample_rate;
 
 			/* do one run to make sure the plans are set up */
 			pitch_scale(buffers, 1.0, FRAME_LENGTH, 4, FRAME_LENGTH, sample_rate, buffers->gInFIFO, buffers->gOutFIFO, 0, 0.0f);

--- a/retro_flange_1208.xml
+++ b/retro_flange_1208.xml
@@ -104,7 +104,7 @@ for (pos = 0; pos < sample_count; pos++) {
 		prev_law_pos = count + law_p;
         }
 
-        n_ph = (float)(law_p - abs(next_law_pos - count))/(float)law_p;
+        n_ph = (float)(law_p - labs(next_law_pos - count))/(float)law_p;
         p_ph = n_ph + 0.5f;
         if (p_ph > 1.0f) {
                 p_ph -= 1.0f;

--- a/ringmod_1188.xml
+++ b/ringmod_1188.xml
@@ -89,8 +89,7 @@
 			offset = 0;
 		</callback>
 
-		<callback event="cleanup">
-			plugin_data = plugin_data;
+		<callback event="cleanup" unused-vars="plugin_data">
 			if (--refcount == 0) {
 				free(sin_tbl);
 				free(tri_tbl);

--- a/step_muxer_1212.xml
+++ b/step_muxer_1212.xml
@@ -38,7 +38,6 @@
       }
       current_ch = 0;
       last_clock = 0.0f;
-      sample_rate = sample_rate;
     ]]></callback>
 
     <callback event="cleanup"><![CDATA[

--- a/tape_delay_1211.xml
+++ b/tape_delay_1211.xml
@@ -45,7 +45,6 @@
 			last_in = 0.0f;
 			last2_in = 0.0f;
 			last3_in = 0.0f;
-			sample_rate = sample_rate;
 			z0 = 0.0f;
 			z1 = 0.0f;
 			z2 = 0.0f;

--- a/transient_1206.xml
+++ b/transient_1206.xml
@@ -42,7 +42,6 @@ fast_track = 0.1;
 medi_track = 0.1;
 slow_track = 0.1;
 count = 0;
-sample_rate = sample_rate;
     </callback>
 
     <callback event="cleanup"><![CDATA[

--- a/util/blo.h
+++ b/util/blo.h
@@ -113,7 +113,7 @@ static inline void blo_hd_set_freq(blo_h_osc *this, const float f)
 	const float ff = fabs(f) + 0.00001f; // Prevent div by zero
 
 	this->om.all = f_round(f * this->ph_coef);
-	tab_num = abs(f_round(this->nyquist / ff - 0.5f));
+	tab_num = f_abs(f_round(this->nyquist / ff - 0.5f));
 	if (tab_num >= BLO_N_HARMONICS) {
 		tab_num = BLO_N_HARMONICS - 1;
 	} else if (tab_num < 0) {

--- a/vocoder_1337.xml
+++ b/vocoder_1337.xml
@@ -72,6 +72,10 @@
     ]]></p>
 
     <callback event="instantiate"><![CDATA[
+      memset(&bands_carrier, 0, sizeof bands_carrier);
+      memset(&bands_formant, 0, sizeof bands_formant);
+      memset(&bands_out, 0, sizeof bands_out);
+
       sample_rate = s_rate;
       main_vol = 1.0 * AMPLIFIER;
 

--- a/vynil_1905.xml
+++ b/vynil_1905.xml
@@ -46,6 +46,8 @@
       buffer_s = malloc(sizeof(LADSPA_Data) * buffer_size);
       buffer_mask = buffer_size - 1;
       buffer_pos = 0;
+      click_buffer_omega.all = 0;
+      click_buffer_pos.all = 0;
       click_gain = 0;
       phi = 0.0f; /* Angular phase */
 


### PR DESCRIPTION
This request deals with these Clang warnings:

* Shifting negative values.
* Possible truncations.
* Uninitialized variables.
* Self-assignments.
* Unused variables.
* Unsupported compiler option.

I add a shell function to `configure.ac` to check compiler options, but you may want to use `AX_CHECK_COMPILE_FLAG` from the Autoconf archive instead. In the XML files, I use an attribute to flag a list of unused variables.