### PR TITLE
Fix tautological compare and use of uninitialized value

### DIFF
--- a/delayorama_1402.xml
+++ b/delayorama_1402.xml
@@ -9,6 +9,7 @@
     <code><![CDATA[
       #include <ladspa-util.h>
 
+      #define MIN(a,b) ((a) < (b) ? (a) : (b))
       #define N_TAPS 128
 
       typedef struct {
@@ -146,7 +147,7 @@
         for (i=0; i<ntaps; i++) {
 	  g_rand = (1.0f-gain_rand) + (float)rand() / (float)RAND_MAX * 2.0f * gain_rand;
 	  d_rand = (1.0f-delay_rand) + (float)rand() / (float)RAND_MAX * 2.0f * delay_rand;
-          taps[next_set][i].delay = LIMIT((unsigned int)(delay_base + delay_sum * delay_fix * d_rand), 0, buffer_size-1);
+          taps[next_set][i].delay = MIN((unsigned int)(delay_base + delay_sum * delay_fix * d_rand), buffer_size-1);
           taps[next_set][i].gain = gain * g_rand;
 
           delay_sum += delay;

--- a/makestub.pl
+++ b/makestub.pl
@@ -206,7 +206,7 @@ sub process_plugin {
 		if ($foo eq "callback") {
 			push(@callbacks, $tree->[$i+1]->[0]->{'event'});
 			$callback_code{$label.'_'.$tree->[$i+1]->[0]->{'event'}} = $tree->[$i+1]->[2];
-			$callback_unused_vars{$label.'_'.$tree->[$i+1]->[0]->{'event'}} = $tree->[$i+1]->[0]->{'unused-vars'};
+			$callback_unused_vars{$label.'_'.$tree->[$i+1]->[0]->{'event'}} = $tree->[$i+1]->[0]->{'unused-vars'} // "";
 		}
 		if ($foo eq "port") {
 			push(@ports, &process_port($tree->[$i+1]));


### PR DESCRIPTION
Fixes:
* `comparison of unsigned expression < 0 is always false` with Clang 3.5.
* `Use of uninitialized value` Perl warning.