### PR TITLE
Windows compat fixes

### DIFF
--- a/makestub.pl
+++ b/makestub.pl
@@ -68,7 +68,7 @@ for (my $i=7; $i<@{$ladspa}; $i+=4) {
 print <<EOB;
 \#include <stdlib.h>
 \#include <string.h>
-\#ifndef WIN32
+\#ifndef _WIN32
 \#include "config.h"
 \#endif
 
@@ -85,7 +85,7 @@ print <<EOB;
 
 \#include "ladspa.h"
 
-\#ifdef WIN32
+\#ifdef _WIN32
 \#define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
 static void __attribute__((constructor)) swh_init(); // forward declaration
@@ -123,7 +123,7 @@ print <<EOB;
 _WINDOWS_DLL_EXPORT_
 const LADSPA_Descriptor *ladspa_descriptor(unsigned long index) {
 
-\#ifdef WIN32
+\#ifdef _WIN32
 	if (bIsFirstTime) {
 		swh_init();
 		bIsFirstTime = 0;


### PR DESCRIPTION
* Disables shared memory objects on Windows
* Standardizes to `_WIN32` precompiler flags per [standard convention](https://stackoverflow.com/a/662095/3196753.).

Note, these shmem precompiler code changes have been shipping with LMMS for Windows [since `cacc0d6` in 2012]( https://github.com/LMMS/lmms/commit/cacc0d6c3e5e497f794f35c539ad045cd3113b8d#diff-2aabc265cc2d4fa05c51d89e0f3f42c7R61) (but somehow never made it upstream).