### PR TITLE
Use List::MoreUtils instead of List::Util

### DIFF
--- a/makestub.pl
+++ b/makestub.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use List::Util qw(any);
+use List::MoreUtils qw(any);
 use XML::Parser;
 
 $xml_line = 1;


### PR DESCRIPTION
Adds compatibility with Ubuntu 14.04 by switching `makestub.pl` to `List:MoreUtils`.  This will add the dependency `liblist-moreutils-perl`, but allows compilation to succeed through Ubuntu 14.04 adding (potential) support for the continuous integration service [Travis-CI](https://docs.travis-ci.com/user/reference/trusty/).

To add this dependency to Ubuntu:
```bash
sudo apt-get install liblist-moreutils-perl
```

See similar problem documented and fixed here https://github.com/tseemann/snippy/commit/dc7ac8b4a75028ef1371f84c45f5daf3232dec30.

