### PR TITLE
Fix spelling error in ladspa

### DIFF
--- a/util/buffer.h
+++ b/util/buffer.h
@@ -1,7 +1,7 @@
 #ifndef _BUFFER_H
 #define _BUFFER_H
 
-/* substract buffer b from a, save in c
+/* subtract buffer b from a, save in c
  *
  * this could be sped up by vector operations
  */


### PR DESCRIPTION
A spelling error that was fixed via a patch in Debian.