### PR TITLE
Remove cyclic include

### DIFF
--- a/gverb/gverb.h
+++ b/gverb/gverb.h
@@ -26,7 +26,6 @@
 #include <math.h>
 #include <string.h>
 #include "gverbdsp.h"
-#include "gverb.h"
 #include "../ladspa-util.h"
 
 #define FDNORDER 4


### PR DESCRIPTION
Hi,

this include caused issues with running `include-what-you-use` in LMMS. Can you please help us by merging this PR, so we can use the tool?

Thanks on advance!