### PR TITLE
Define `_USE_MATH_DEFINES` for `M_PI`

### DIFF
--- a/am_pitchshift_1433.xml
+++ b/am_pitchshift_1433.xml
@@ -9,6 +9,9 @@
     <meta name="properties" value="HARD_RT_CAPABLE"/>
     <code><![CDATA[
       #include <stdlib.h>
+      #ifndef _USE_MATH_DEFINES
+      #define _USE_MATH_DEFINES /* required for M_PI on some systems */
+      #endif
       #include <math.h>
 
       #include "ladspa-util.h"


### PR DESCRIPTION
`M_PI` came with fd3d97ae504a5c921a0ba6b3481fc90f2e486b08 , but it
requires the `_USE_MATH_DEFINES` macro on some systems.