### PR TITLE
Make shebang more flexible (use /usr/bin/env)

### DIFF
--- a/bozosoity-checker.pl
+++ b/bozosoity-checker.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
+use warnings;
 
 %used = ();
 

--- a/docs/addstyle.pl
+++ b/docs/addstyle.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
+use warnings;
 
 $style = <<EOB;
 <style>

--- a/docs/makedocs.pl
+++ b/docs/makedocs.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
+use warnings;
 
 use XML::Parser;
 

--- a/impulses/reorder.pl
+++ b/impulses/reorder.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 $n = 1;
 while (<>) {

--- a/impulses/scale.pl
+++ b/impulses/scale.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 $scale = shift;
 

--- a/makestub.pl
+++ b/makestub.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
+use warnings;
 
 use List::MoreUtils qw(any);
 use XML::Parser;

--- a/metadata/lxml2rdf.pl
+++ b/metadata/lxml2rdf.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
+use warnings;
 
 print <<EOB;
 <?xml version='1.0' encoding='ISO-8859-1'?>

--- a/metadata/txt2scale.pl
+++ b/metadata/txt2scale.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
+use warnings;
 
 print <<EOB;
 <?xml version='1.0' encoding='UTF-8'?>

--- a/mkspec.pl
+++ b/mkspec.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
+use warnings;
 
 $package = shift(@ARGV);
 $version = shift(@ARGV);

--- a/timetest/autotimetest.pl
+++ b/timetest/autotimetest.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
+use warnings;
 
 $html = 0;
 $skip = 0;

--- a/timetest/timecmp
+++ b/timetest/timecmp
@@ -1,4 +1,5 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
+use warnings;
 
 my $pattern = shift @ARGV;
 

--- a/timetest/timetest
+++ b/timetest/timetest
@@ -1,4 +1,5 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
+use warnings;
 
 my $pattern = shift @ARGV;
 


### PR DESCRIPTION
This pull request changes basically two things:

- Replace the `-w` option in the shebang by `use warnings;`
- Use `/usr/bin/env` to call perl instead of hard-coded path `/usr/bin/perl`. Using `/usr/bin/env` will look for perl in the locations of the `PATH` environment variable.
