### PR TITLE
Remove hypotesis than build directory is project root

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -92,7 +92,7 @@ butterworth_1902_la_SOURCES = butterworth_1902.c
 
 # Rule to build .c files from XML source
 %.c:	%.xml
-	! test -f "$*.xml" || ./makestub.pl "$*.xml" > "$*.c"
+	! test -f "$^" || @top_srcdir@/makestub.pl "$^" > "$@"
 
 #strip .libs/$$file;
 


### PR DESCRIPTION
Hi,

I was working on a swh-ladspa package for libreelec when i had a problem to build the project. The probleme was that the makefile was written under the hypotesis that the build directory is the project root, which is not true when compiling with libreelec build system.

I wrote a patch for than, and i thought you may be intrested.

Cheers