### PR TITLE
Fixes to enable building swh on msvc

### DIFF
--- a/ladspa-util.h
+++ b/ladspa-util.h
@@ -7,6 +7,10 @@
 #ifndef LADSPA_UTIL_H
 #define LADSPA_UTIL_H
 
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
+#endif
+
 #include <math.h>
 #include <stdint.h>
 

--- a/makestub.pl
+++ b/makestub.pl
@@ -81,6 +81,9 @@ print <<EOB;
 \#define         __USE_ISOC99    1
 \#define         __USE_ISOC9X    1
 
+\#ifndef _USE_MATH_DEFINES
+\#define _USE_MATH_DEFINES
+\#endif
 \#include <math.h>
 
 \#include "ladspa.h"

--- a/sinus_wavewrapper_1198.xml
+++ b/sinus_wavewrapper_1198.xml
@@ -13,6 +13,11 @@
                 <p>Produces an unusual distortion effect, for a more amp like tone, see the valve saturation plugin (section \ref{valve}).</p>
 
 		<callback event="run"><![CDATA[
+
+			#ifndef _USE_MATH_DEFINES
+			#define _USE_MATH_DEFINES
+			#endif
+
 			float coef = wrap * M_PI;
 			unsigned long pos;
 

--- a/sinus_wavewrapper_1198.xml
+++ b/sinus_wavewrapper_1198.xml
@@ -13,11 +13,6 @@
                 <p>Produces an unusual distortion effect, for a more amp like tone, see the valve saturation plugin (section \ref{valve}).</p>
 
 		<callback event="run"><![CDATA[
-
-			#ifndef _USE_MATH_DEFINES
-			#define _USE_MATH_DEFINES
-			#endif
-
 			float coef = wrap * M_PI;
 			unsigned long pos;
 

--- a/util/pitchscale.c
+++ b/util/pitchscale.c
@@ -37,7 +37,6 @@
 
 #include <string.h>
 #include "../config.h"
-#include <math.h>
 
 #include "pitchscale.h"
 

--- a/util/pitchscale.h
+++ b/util/pitchscale.h
@@ -3,6 +3,12 @@
 
 #include <config.h>
 
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
+#endif
+
+#include <math.h>
+
 #ifdef FFTW3
 
 #include <fftw3.h>


### PR DESCRIPTION
I've been trying to enable building LADSPA plugins on msvc for LMMS. While looking at the commit history, I found that there were a few attempts here to fix swh, but unfortunately, they were incomplete. Building on top of what we have, I managed to complete the task and here's the PR. 